### PR TITLE
fix search with filetype

### DIFF
--- a/lua/browse/devdocs.lua
+++ b/lua/browse/devdocs.lua
@@ -3,7 +3,7 @@ local utils = require("browse.utils")
 local M = {}
 
 M.search_with_filetype = utils.callback_search(function(input)
-  local input_with_filetype = vim.bo.filetype .. " " .. input
+  local input_with_filetype = vim.bo.filetype .. "%20" .. input
 
   return string.format("https://devdocs.io/#q=%s", input_with_filetype)
 end)


### PR DESCRIPTION
on osx, when using require('browse.devdocs').search_with_filetype() it opens the browser with 'Page not found' and 
browser.url = https://devdocs.io/%23q=go%20join, when searching for the text **join** in a .go file (golang) 

this change fixed it