### PR TITLE
Feature improve alias search

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ require('browse').setup({
   -- either pass it here or just pass the table to the functions
   -- see below for more
   bookmarks = {}
+  icons = {
+      bookmark_alias = "->", -- if you have nerd fonts, you can set this to ""
+      bookmarks_prompt = "", -- if you have nerd fonts, you can set this to "󰂺 "
+      grouped_bookmarks = "->", -- if you have nerd fonts, you can set this to 
+  }
 })
 ```
 

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -29,10 +29,6 @@ M.search_bookmarks = function(config)
         end
     end
 
-    local function get_domain(url)
-        return string.match(url, "https?://([^/]+)")
-    end
-
     local function entry_maker(entry)
         local value, display, ordinal
 

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -29,6 +29,10 @@ M.search_bookmarks = function(config)
         end
     end
 
+    local function get_domain(url)
+        return string.match(url, "https?://([^/]+)")
+    end
+
     local function entry_maker(entry)
         local value, display, ordinal
 

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -42,11 +42,11 @@ M.search_bookmarks = function(config)
             ordinal = entry
         elseif type(entry) == "table" and type(entry[2]) ~= "table" then
             value = entry[2]
-            display = entry[1] .. " -> " .. value
+            display = entry[1] .. "  " .. value
             ordinal = entry[1] .. entry[2]
         elseif type(entry) == "table" and type(entry[2]) == "table" then
             ordinal = entry[1]
-            display = entry[1] .. " ->"
+            display = entry[1] .. " "
 
             for k, v in pairs(entry[2]) do
                 ordinal = ordinal .. k .. v

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -45,8 +45,8 @@ M.search_bookmarks = function(config)
             display = entry[1] .. "  " .. value
             ordinal = entry[1] .. entry[2]
         elseif type(entry) == "table" and type(entry[2]) == "table" then
-            ordinal = entry[1]
             display = entry[1] .. " "
+            ordinal = entry[1]
 
             for k, v in pairs(entry[2]) do
                 ordinal = ordinal .. k .. v

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -13,6 +13,7 @@ local M = {}
 -- search bookmarks
 M.search_bookmarks = function(config)
     config = config or {}
+    local icons = config["icons"] or defaults.opts["icons"] or {}
     local bookmarks = config["bookmarks"] or defaults.opts["bookmarks"] or {}
     local visual_text = config["visual_text"]
     local bookmarks_copy = vim.deepcopy(bookmarks)
@@ -38,10 +39,10 @@ M.search_bookmarks = function(config)
             ordinal = entry
         elseif type(entry) == "table" and type(entry[2]) ~= "table" then
             value = entry[2]
-            display = entry[1] .. "  " .. value
+            display = entry[1] .. " " .. icons.bookmark_alias .. " " .. value
             ordinal = entry[1] .. entry[2]
         elseif type(entry) == "table" and type(entry[2]) == "table" then
-            display = entry[1] .. " "
+            display = entry[1] .. " " .. icons.grouped_bookmarks
             ordinal = entry[1]
 
             for k, v in pairs(entry[2]) do
@@ -50,7 +51,7 @@ M.search_bookmarks = function(config)
                 if type(k) == "string" then
                     display = display .. " " .. k
                 else
-                    display = display .. " " .. get_domain(v)
+                    display = display .. " " .. utils.get_domain(v)
                 end
             end
 
@@ -85,7 +86,7 @@ M.search_bookmarks = function(config)
 
     pickers
         .new(opts, {
-            prompt_title = "󰂺 Bookmarks",
+            prompt_title = icons.bookmarks_prompt .. "Bookmarks",
             finder = create_finder(),
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(prompt_bufnr, _)

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -45,9 +45,22 @@ M.search_bookmarks = function(config)
             display = entry[1] .. " -> " .. value
             ordinal = entry[1] .. entry[2]
         elseif type(entry) == "table" and type(entry[2]) == "table" then
+            ordinal = entry[1]
+            display = entry[1] .. " ->"
+
+            for k, v in pairs(entry[2]) do
+                ordinal = ordinal .. k .. v
+
+                if type(k) == "string" then
+                    display = display .. " " .. k
+                else
+                    display = display .. " " .. get_domain(v)
+                end
+            end
+
             value = entry[2]
-            display = entry[1] .. " -> " .. (entry[2]["name"] or "")
-            ordinal = (entry[2]["name"] or "")
+            display = display
+            ordinal = ordinal
         end
 
         return {

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -72,7 +72,7 @@ M.search_bookmarks = function(config)
 
     pickers
         .new(opts, {
-            prompt_title = "Bookmarks",
+            prompt_title = "󰂺 Bookmarks",
             finder = create_finder(),
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(prompt_bufnr, _)

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -43,7 +43,7 @@ M.search_bookmarks = function(config)
         elseif type(entry) == "table" and type(entry[2]) ~= "table" then
             value = entry[2]
             display = entry[1] .. " -> " .. value
-            ordinal = value
+            ordinal = entry[1] .. entry[2]
         elseif type(entry) == "table" and type(entry[2]) == "table" then
             value = entry[2]
             display = entry[1] .. " -> " .. (entry[2]["name"] or "")

--- a/lua/browse/config.lua
+++ b/lua/browse/config.lua
@@ -11,9 +11,9 @@ M.opts = {
         -- ["github_repo_search"] = "https://github.com/search?q=%s&type=respositories",
     },
     icons = {
-        bookmark_alias = "->", -- if you have nerd fonts, you can set this to ""
-        bookmarks_prompt = "", -- if you have nerd fonts, you can set this to "󰂺 "
-        grouped_bookmarks = "->", -- if you have nerd fonts, you can set this to 
+        bookmark_alias = "->",
+        bookmarks_prompt = "",
+        grouped_bookmarks = "->",
     },
 }
 

--- a/lua/browse/config.lua
+++ b/lua/browse/config.lua
@@ -10,6 +10,11 @@ M.opts = {
         -- ["github_code_search"] = "https://github.com/search?q=%s&type=code",
         -- ["github_repo_search"] = "https://github.com/search?q=%s&type=respositories",
     },
+    icons = {
+        bookmark_alias = "->", -- if you have nerd fonts, you can set this to ""
+        bookmarks_prompt = "", -- if you have nerd fonts, you can set this to "󰂺 "
+        grouped_bookmarks = "->", -- if you have nerd fonts, you can set this to 
+    },
 }
 
 function M.setup(opts)

--- a/lua/browse/init.lua
+++ b/lua/browse/init.lua
@@ -27,11 +27,11 @@ local browse = function(config)
 
             finder = finders.new_table({
                 results = {
-                    { "Bookmarks Search",             "bookmarks" },
-                    { "Devdocs Search",               "devdocs" },
+                    { "Bookmarks Search", "bookmarks" },
+                    { "Devdocs Search", "devdocs" },
                     { "Devdocs Search with filetype", "devdocs_file" },
-                    { "Input Search",                 "input" },
-                    { "MDN Web Docs",                 "mdn" },
+                    { "Input Search", "input" },
+                    { "MDN Web Docs", "mdn" },
                 },
                 entry_maker = function(entry)
                     return {
@@ -52,7 +52,10 @@ local browse = function(config)
                     local browse_selection = selection["ordinal"]
 
                     if browse_selection == "bookmarks" then
-                        search_bookmarks({ bookmarks = bookmarks, visual_text = visual_text })
+                        search_bookmarks({
+                            bookmarks = bookmarks,
+                            visual_text = visual_text,
+                        })
                     elseif browse_selection == "input" then
                         search_input(visual_text)
                     elseif browse_selection == "devdocs" then

--- a/lua/browse/utils.lua
+++ b/lua/browse/utils.lua
@@ -7,9 +7,9 @@ local get_os_name = function()
     return os_name
 end
 
--- WSL 
-local is_wsl = function ()
-    local output = vim.fn.systemlist "uname -r"
+-- WSL
+local is_wsl = function()
+    local output = vim.fn.systemlist("uname -r")
     return not not string.find(output[1] or "", "WSL")
 end
 
@@ -24,9 +24,9 @@ local get_open_cmd = function()
         open_cmd = { "open" }
     else
         if is_wsl() then
-          open_cmd = { "wsl-open" }
+            open_cmd = { "wsl-open" }
         else
-          open_cmd = { "xdg-open" }
+            open_cmd = { "xdg-open" }
         end
     end
     return open_cmd
@@ -78,14 +78,17 @@ end
 M.search = function(target_fn, opts)
     local prompt = opts and opts.prompt or "Search String:"
     local default = opts and opts.visual_text or ""
-    vim.ui.input({ prompt = prompt, default = default, kind = "browse" }, function(input)
-        if input == nil or input == "" then
-            return
-        end
+    vim.ui.input(
+        { prompt = prompt, default = default, kind = "browse" },
+        function(input)
+            if input == nil or input == "" then
+                return
+            end
 
-        local escaped_input = escape_target(vim.fn.trim(input))
-        M.default_search(target_fn(escaped_input))
-    end)
+            local escaped_input = escape_target(vim.fn.trim(input))
+            M.default_search(target_fn(escaped_input))
+        end
+    )
 end
 
 -- a generic searching closure util

--- a/lua/browse/utils.lua
+++ b/lua/browse/utils.lua
@@ -116,4 +116,12 @@ M.get_visual_text = function()
     return string.gsub(sel_text, "\n", "")
 end
 
+--Get the domain of a URL
+--Example: https://obsidian.md => obsidian.md
+---@param url string: URL to which your domain will be extracted
+---@return string: Domain from the URL
+M.get_domain = function(url)
+    return string.match(url, "https?://([^/]+)")
+end
+
 return M

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+call_parentheses = "Always"
+column_width = 80
+indent_type = "Spaces"
+indent_width = 4
+line_endings = "Unix"
+quote_style = "ForceDouble"


### PR DESCRIPTION
# Improve alias search

My solution to https://github.com/lalitmee/browse.nvim/issues/19

```lua
local bookmarks = {
	parq = {
		passes = 'https://main.d2xuop51ekcwbf.amplifyapp.com',
		payvalida_doc = 'https://docs.payvalida.com/documentacion',
		payvalida_sandbox = 'https://sandbox-merchant.payvalida.com/signin',
	},
	tools = {
		'https://obsidian.md/',
		'https://www.notion.so/',
	},
	reddit = 'https://www.reddit.com/r/neovim',
	youtube = 'https://www.youtube.com',
	'https://github.com/lalitmee/browse.nvim/issues/19',
}
```
> Bookmarks used for the show cases

# Changes
1. Icons to increase accessibility for users using terminals or fonts with ligature support, and have different meanings.
    - Prompt icon.
    - Icon for bookmarks with aliases.
    - Icon for grouped bookmarks.
![image](https://github.com/lalitmee/browse.nvim/assets/62358156/2ce6cc4f-259e-4be6-8bdb-101db56a7876)
2. Improved searches, both for aliases and for grouped aliases and grouped bookmarks
    - When you search in this case for `parq`, it now occupies the payload to search for it among the aliases and their urls
![image](https://github.com/lalitmee/browse.nvim/assets/62358156/23bcc301-ba3a-4ebd-9b20-dc6d1eb475bb)
    - Likewise for those who are grouped but without aliases.
![image](https://github.com/lalitmee/browse.nvim/assets/62358156/27942351-3bc8-428b-9df7-2df8d16cd19d)
    - Here in this example we see that we use the payload `sign`, which would be part of the url of `payvalida_sandbox` and we math it.
![image](https://github.com/lalitmee/browse.nvim/assets/62358156/96a79efc-348d-4e54-a6dc-fccc64427005)
3. Accessibility to understand why `X` searches are paired. For the grouped aliases I have used the aliases after the icon that indicates that they are grouped aliases and for the grouped aliases without aliases I used a function that returns the domain and made me have a better UX/IU.

![image](https://github.com/lalitmee/browse.nvim/assets/62358156/357699a2-2702-4017-869f-480a05c8d8d2)
