### PR TITLE
Feature persist grouped bookmarks query

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ require('browse').setup({
       bookmarks_prompt = "", -- if you have nerd fonts, you can set this to "󰂺 "
       grouped_bookmarks = "->", -- if you have nerd fonts, you can set this to 
   }
+  -- if you want to persist the query for grouped bookmarks
+  -- See https://github.com/lalitmee/browse.nvim/pull/23
+  persist_grouped_bookmarks_query = false,
 })
 ```
 

--- a/lua/browse/bookmarks.lua
+++ b/lua/browse/bookmarks.lua
@@ -14,6 +14,9 @@ local M = {}
 M.search_bookmarks = function(config)
     config = config or {}
     local icons = config["icons"] or defaults.opts["icons"] or {}
+    local persist_grouped_bookmarks_query = config["persist_grouped_bookmarks_query"]
+        or defaults.opts["persist_grouped_bookmarks_query"]
+        or false
     local bookmarks = config["bookmarks"] or defaults.opts["bookmarks"] or {}
     local visual_text = config["visual_text"]
     local bookmarks_copy = vim.deepcopy(bookmarks)
@@ -107,8 +110,19 @@ M.search_bookmarks = function(config)
 
                         local list = remove_element(tbl_copy, "name")
 
+                        local search_bookmarks_opts = {
+                            bookmarks = list,
+                            visual_text,
+                        }
+
+                        if persist_grouped_bookmarks_query then
+                            local query = action_state.get_current_line()
+
+                            search_bookmarks_opts.default_text = query
+                        end
+
                         -- search bookmarks with the new list
-                        M.search_bookmarks({ bookmarks = list, visual_text })
+                        M.search_bookmarks(search_bookmarks_opts)
                     elseif type(value) == "string" then
                         -- checking for `%` in the url
                         if string.match(value, "%%") then

--- a/lua/browse/config.lua
+++ b/lua/browse/config.lua
@@ -15,6 +15,7 @@ M.opts = {
         bookmarks_prompt = "",
         grouped_bookmarks = "->",
     },
+    persist_grouped_bookmarks_query = false,
 }
 
 function M.setup(opts)


### PR DESCRIPTION
## ⏺ Description

This PR introduces the `persist_grouped_bookmarks_query` option in the browse setup. This new functionality ensures that when searching within a grouped bookmark, the query is persisted, allowing users to avoid re-entering the same query multiple times.

### 😃 Key Benefits
- Improves user experience by maintaining the search query during grouped bookmark lookups.
- Reduces repetitive typing and streamlines search workflows.

## Demo

https://github.com/user-attachments/assets/46768012-21a1-43d5-b1fe-d357ab3ae3a8

